### PR TITLE
tabindex fixed in signup form

### DIFF
--- a/lib/signup/signup-form.jade
+++ b/lib/signup/signup-form.jade
@@ -37,11 +37,11 @@
             option(value='Docente') Docente
       .form-group
         label= t('Password')
-        input.form-control(type='password', name='password', tabindex=4, placeholder=t('Password'), validate='required min-length:6')
+        input.form-control(type='password', name='password', tabindex=6, placeholder=t('Password'), validate='required min-length:6')
       .form-group
         label= t('Re-type password')
-        input.form-control(type='password', name='re_password', tabindex=5, placeholder=t('Repeat Password'), validate='required same:password')
-      .form-group: button.btn.btn-success.btn-block.btn-lg(tabindex=6)=t('Signup now!')
+        input.form-control(type='password', name='re_password', tabindex=7, placeholder=t('Repeat Password'), validate='required same:password')
+      .form-group: button.btn.btn-success.btn-block.btn-lg(tabindex=8)=t('Signup now!')
       .form-group
         - var tos = config['tos'];
         - var pp = config['pp'];


### PR DESCRIPTION
The signup form fields' `tabIndex` was wrong, going back from password to career.

I hope this fixes it, but haven't tested - I've to setup the environment yet.